### PR TITLE
fix 502

### DIFF
--- a/Turbosms.php
+++ b/Turbosms.php
@@ -245,7 +245,7 @@ class Turbosms extends Component
             'text' => $text
         ]);
 
-        if (!empty($result->SendSMSResult->ResultArray[1])) {
+        if (is_array($result->SendSMSResult->ResultArray) && !empty($result->SendSMSResult->ResultArray[1])) {
             $this->lastSendMessageId = $result->SendSMSResult->ResultArray[1];
         }
 


### PR DESCRIPTION
при непідтвердженому альфаімені 
$result->SendSMSResult->ResultArray[1] - не існує, але туди вертається символ, який потім, не можливо зберегти в БД
і метод model->save()  не відпрацьовує
 додав перевірку на масив
